### PR TITLE
Use sentry_sdk, disable legacy plugin/.py configs, strengthen regexes and logging

### DIFF
--- a/LinuxTimeMachine/backup.py
+++ b/LinuxTimeMachine/backup.py
@@ -21,7 +21,6 @@ from logging import getLogger
 from subprocess import call, Popen, PIPE, check_output
 
 import pexpect
-from yapsy.PluginManager import PluginManager
 
 from . import exceptions
 from .common import Log
@@ -54,9 +53,8 @@ POSSIBILITY OF SUCH DAMAGE."""
 
 class Plugins:
     def __init__(self):
-        self.manager = PluginManager()
-        self.manager.setPluginPlaces([Tools.get_here_path() + "/plugins"])
-        self.manager.collectPlugins()
+        self.manager = None
+        Log.warning("Plugin subsystem is disabled for modern Python compatibility")
 
 
 class Console:
@@ -144,7 +142,7 @@ class Console:
                     "-maxdepth", "1",
                     "-type", "d",
                     "-regextype", "grep",
-                    "-regex", path + "/[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}_[0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}"
+                    "-regex", path + r"/[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}_[0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}"
                 ]
             ), host
         )
@@ -490,7 +488,7 @@ class Mysql:
                 p.sendline(self.password)
                 p.read(len(self.password) + 1)
                 data = p.read().decode("UTF-8")
-                if re.search("ERROR\ [0-9]+.*?at line [0-9]+:", data):
+                if re.search(r"ERROR [0-9]+.*?at line [0-9]+:", data):
                     raise exceptions.MysqlError("MysqlError: " + data + ", command was: " + cmd)
                 return data
             elif res == "eof":
@@ -557,7 +555,7 @@ class Mysql:
         dbs = {}
 
         for line in checksums.split("\n"):
-            matches = re.match("(?P<name>.*?\..*?)\t(?P<checksum>[0-9]+)", line)
+            matches = re.match(r"(?P<name>.*?\..*?)\t(?P<checksum>[0-9]+)", line)
             if matches:
                 name = matches.groupdict()['name']
                 checksum = int(matches.groupdict()['checksum'])
@@ -649,7 +647,7 @@ class Mysql:
         """
         Log.info("Removing dump from: " + root_folder)
         Console.call_shell(
-            Console.cmd("find '" + root_folder + "' -type f -name *.sql -exec rm_file {} \;", self.sshhost)
+            Console.cmd("find '" + root_folder + "' -type f -name *.sql -exec rm {} \\;", self.sshhost)
         )
         Console.call_shell(
             Console.cmd("find '" + root_folder + "' -type d -empty -delete")
@@ -804,7 +802,7 @@ class Mysql:
 
         result = Console.call_shell_and_return(cmd).decode("UTF-8").split("\n")
         reg = re.compile(
-            "INFO: -- LTMINFO: TMVERSION:#(?P<TMVERSION>[0-9\.]+)#  DB:#(?P<DB>[^#]+)# TBL:#(?P<TBL>[^#]+)# TABLEUPDATEDATE:#(?P<TABLEUPDATEDATE>[^#]+)# (TABLECHECKSUM:#(?P<TABLECHECKSUM>[^#]+)# )?\ ?FILE:#(?P<FILE>[^#]+)#")
+            r"INFO: -- LTMINFO: TMVERSION:#(?P<TMVERSION>[0-9\.]+)#  DB:#(?P<DB>[^#]+)# TBL:#(?P<TBL>[^#]+)# TABLEUPDATEDATE:#(?P<TABLEUPDATEDATE>[^#]+)# (TABLECHECKSUM:#(?P<TABLECHECKSUM>[^#]+)# )?\ ?FILE:#(?P<FILE>[^#]+)#")
         for line in result:
             matches = reg.search(line)
             if matches:
@@ -947,9 +945,9 @@ class Rsync:
         self.line_parsers = [
             {
                 "type": "progress",
-                "re": "(?P<bytes>[0-9,]+)\s+(?P<progress>[0-9]+)%\s+(?P<speed>[0-9\.]+[MKGTmkgt])B/s\s+" +
-                      "(?P<time>(?P<hour>[0-9]+):(?P<minute>[0-9]+):(?P<second>[0-9]+))\s+" +
-                      "\(xfr#(?P<xfr_num>[0-9]+), ir-chk=(?P<ir_chk_top>[0-9]+)/(?P<ir_chk_bottom>[0-9]+)\)",
+                "re": r"(?P<bytes>[0-9,]+)\s+(?P<progress>[0-9]+)%\s+(?P<speed>[0-9\.]+[MKGTmkgt])B/s\s+" +
+                      r"(?P<time>(?P<hour>[0-9]+):(?P<minute>[0-9]+):(?P<second>[0-9]+))\s+" +
+                      r"\(xfr#(?P<xfr_num>[0-9]+), ir-chk=(?P<ir_chk_top>[0-9]+)/(?P<ir_chk_bottom>[0-9]+)\)",
                 "parser": lambda res: {
                     "time": int(res['second']) + 60 * int(res['minute']) + 3600 * int(res['hour']),
                     "type": "progress",
@@ -963,8 +961,8 @@ class Rsync:
             },
             {
                 "type": "progress",
-                "re": "(?P<bytes>[0-9,]+)\s+(?P<progress>[0-9]+)%\s+(?P<speed>[0-9\.]+[MKGTmkgt])B/s\s+" +
-                      "(?P<time>(?P<hour>[0-9]+):(?P<minute>[0-9]+):(?P<second>[0-9]+))\s+",
+                "re": r"(?P<bytes>[0-9,]+)\s+(?P<progress>[0-9]+)%\s+(?P<speed>[0-9\.]+[MKGTmkgt])B/s\s+" +
+                      r"(?P<time>(?P<hour>[0-9]+):(?P<minute>[0-9]+):(?P<second>[0-9]+))\s+",
                 "parser": lambda res: {
                     "time": int(res['second']) + 60 * int(res['minute']) + 3600 * int(res['hour']),
                     "type": "progress",
@@ -988,8 +986,8 @@ class Rsync:
             },
             {
                 "type": "result_stat",
-                "re": ("sent\ +(?P<sent>[0-9,]+)" +
-                       "\ +bytes\ +received\ +(?P<received>[0-9,]+)\ +bytes\ +(?P<speed>[0-9,\.]+) bytes/sec"),
+                "re": (r"sent\ +(?P<sent>[0-9,]+)" +
+                       r"\ +bytes\ +received\ +(?P<received>[0-9,]+)\ +bytes\ +(?P<speed>[0-9,\.]+) bytes/sec"),
                 "parser": lambda res: {
                     "type": "result_stat",
                     "sent": int(res['sent'].replace(',', "")),
@@ -1326,5 +1324,4 @@ def go(variants, rsync_callback=Rsync.default_callback, verbose=False, skip_freq
             ravenClient().capture_exceptions(e)
 
         Console.print_asterisked("Backup is done, full time is:" + str(summ_time))
-
 

--- a/LinuxTimeMachine/common.py
+++ b/LinuxTimeMachine/common.py
@@ -95,7 +95,7 @@ class Tools:
             delta = datetime.timedelta(**params)
         elif type(src) == str:
             matches = re.findall(
-                "(([0-9]+)\ *(days|weeks|hours|minutes|seconds|milliseconds|microseconds))",
+                r"(([0-9]+)\ *(days|weeks|hours|minutes|seconds|milliseconds|microseconds))",
                 re.sub("[,;]", " ", src)
             )
             params = {}

--- a/LinuxTimeMachine/conf.py
+++ b/LinuxTimeMachine/conf.py
@@ -3,14 +3,13 @@ from .common import Tools
 from . import exceptions
 
 from collections import OrderedDict as Odict
-from raven import Client as RavenClient
 
 import re
 import importlib
+import importlib.util
 import os
 import json
 import yaml
-import types
 import sys
 
 
@@ -18,24 +17,38 @@ class DummyRavenCallable():
     def __init__(self, field_name):
         self.field_name = field_name
     def __call__(self, *args, **kwargs):
-        print("Called DummyRavenObject->" + self.field_name)
+        Log.debug("Called DummyRavenObject->%s", self.field_name)
 
 
 class DummyRavenObject():
     def __getattr__(self, item):
-        print("Requested item `{}` from DummyRavenObject".format(item))
+        Log.debug("Requested item `%s` from DummyRavenObject", item)
         return DummyRavenCallable(item)
+
+
+class SentryClientWrapper:
+    def __init__(self, dsn):
+        self.module = importlib.import_module("sentry_sdk")
+        self.module.init(dsn=dsn)
+
+    def capture_exceptions(self, exc):
+        self.module.capture_exception(exc)
 
 
 def ravenClient(dsn=None):
     """
-    :return: RavenClient
+    Returns Sentry-compatible client object (or dummy object when DSN/dependency is absent).
     """
     if not hasattr(ravenClient, "client_object"):
-        if dsn is not None:
-            ravenClient.client_object = RavenClient(dsn)
-        else:
+        if dsn is None:
             return DummyRavenObject()
+
+        if importlib.util.find_spec("sentry_sdk") is not None:
+            ravenClient.client_object = SentryClientWrapper(dsn)
+        else:
+            Log.warning("Sentry DSN is configured, but sentry_sdk is not installed")
+            ravenClient.client_object = DummyRavenObject()
+
     return ravenClient.client_object
 
 
@@ -62,32 +75,26 @@ class MainConf:
             ravenClient(self.raven_dsn)
 
     def loadFile(self, confFile):
-        print("Loading main conf from " + confFile)
+        Log.info("Loading main conf from %s", confFile)
         regs = {
-            "py": ".*\.py3?$",
-            "json": ".*\.json$",
-            "yaml": ".*\.ya?ml$"
+            "json": r".*\.json$",
+            "yaml": r".*\.ya?ml$"
         }
         filetype = None
         for typename in regs:
             if re.search(regs[typename], confFile):
                 filetype = typename
-                print("File type is:" + typename)
+                Log.debug("Main config file type is: %s", typename)
                 break
         if filetype is None:
-            raise Exception("File type of " + confFile + " not detected. Extension should be .py, .py3, .json, .yml, .yaml")
+            raise Exception("File type of " + confFile + " not detected. Extension should be .json, .yml, .yaml")
 
         if filetype == "json":
             with open(confFile, "r") as f:
                 self.conf = json.load(f)
         elif filetype == "yaml":
             with open(confFile, "r") as f:
-                self.conf = yaml.load(f)
-        elif filetype == "py":
-            spec = importlib.util.spec_from_file_location("module", confFile)
-            foo = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(foo)
-            self.conf = foo.conf
+                self.conf = yaml.safe_load(f)
 
     def readConf(self, confFile=None):
         if confFile is not None:
@@ -101,20 +108,8 @@ class MainConf:
 class Conf:
     """
     Configuration reader class
-    reads files of py, json and yaml types.
+    reads files of json and yaml types.
     File structure have to be:
-
-    for python:
-
-    variants = {
-        "variant1" : {
-            ...
-        },
-        "variant2" : {
-            ...
-        }
-        ...
-    }
 
     for json:
 
@@ -145,7 +140,7 @@ class Conf:
         """
         if (not os.path.exists(dir_path)):
             Log.error("Configuration folder '{}' doesn't exists".format(dir_path))
-        filenames = [file for file in os.listdir(dir_path) if re.search("\.(py3?|ya?ml|json)$", file)]
+        filenames = [file for file in os.listdir(dir_path) if re.search(r"\.(ya?ml|json)$", file)]
         files = [dir_path + "/" + file for file in sorted(filenames)]
         if len(files) == 0:
             Log.error("There are no config files in folder '{}'".format(dir_path))
@@ -172,32 +167,10 @@ class Conf:
         return data
 
     @staticmethod
-    def read_py_conf_file(file):
-        """
-        Read .py config file
-        :param file: filename
-        :return: nested dict with variants, readed from file
-        """
-        path = os.path.dirname(file)
-        curpath = os.path.curdir
-        os.chdir(path)
-        justfile = os.path.basename(file)
-        with open(justfile, "r") as f:
-            code = f.read()
-        new_module = types.ModuleType("new_temporary_module")
-        exec(code, new_module.__dict__)
-        os.chdir(curpath)
-        if "variants" in new_module.__dict__:
-            return new_module.variants
-        else:
-            pass
-
-
-    @staticmethod
     def read_conf_file(filename):
         """
         Read single config file
-        :param filename: file name, should have "*.py", "*.json", "*.yaml" or "*.yml" extension, so, loader
+        :param filename: file name, should have "*.json", "*.yaml" or "*.yml" extension, so, loader
                          could recognize, what method should be used to load file
         :return: dict, containing backup variants from file
         """
@@ -206,9 +179,8 @@ class Conf:
             raise exceptions.ConfigFileNotExists("File `" + filename + "` not exists")
 
         regs = {
-            "py": ".*\.py3?$",
-            "json": ".*\.json$",
-            "yaml": ".*\.ya?ml$"
+            "json": r".*\.json$",
+            "yaml": r".*\.ya?ml$"
         }
 
         filetype = None
@@ -217,7 +189,7 @@ class Conf:
                 filetype = curtype
                 break
         if filetype is None:
-            raise exceptions.BadConfigFile("Config file {} must have extension .py, .json, .yaml or .yml".format(filename))
+            raise exceptions.BadConfigFile("Config file {} must have extension .json, .yaml or .yml".format(filename))
         content = ""
         with open(filename, "r") as f:
             content = f.read()
@@ -225,11 +197,9 @@ class Conf:
         conf = {}
 
         if content:
-            if filetype == "py":
-                conf = Conf.read_py_conf_file(filename)
-            elif filetype == "json":
+            if filetype == "json":
                 conf = json.loads(content)
             elif filetype == "yaml":
-                conf = yaml.load(StringIO(content))
+                conf = yaml.safe_load(content)
 
         return conf

--- a/LinuxTimeMachine/go.py
+++ b/LinuxTimeMachine/go.py
@@ -3,6 +3,7 @@ from .conf import Conf
 from .backup import go as backup_go
 from LinuxTimeMachine.sweep import sweep as sweep_go
 from .conf import MainConf
+from .common import Log
 import click
 import os
 import re
@@ -16,19 +17,19 @@ def process_variants(conf_dir, conf, run, dontrun, here):
     confs = {}
 
     if here and len(run):
-        print("Error: --run and --here shouldn't be used together!")
+        Log.error("Error: --run and --here should not be used together")
         return None
 
     if len(conf):
         conf_files = [item.name for item in conf]
-        print("Using specified config files: {}".format(", ".join(conf_files)))
+        Log.info("Using specified config files: %s", ", ".join(conf_files))
         conf_data = Conf.read_conf_files(conf_files)
     elif conf_dir:
-        print("Using specified config folder '{}'".format(conf_dir))
+        Log.info("Using specified config folder `%s`", conf_dir)
         conf_data = Conf.read_conf_dir(conf_dir)
     else:
         dir = os.path.expanduser("~/.config/LinuxTimeMachine/variants")
-        print("Using default config folder '{}'".format(dir))
+        Log.info("Using default config folder `%s`", dir)
         if not os.path.exists(dir):
             os.makedirs(dir)
         conf_data = Conf.read_conf_dir(dir)
@@ -46,34 +47,30 @@ def process_variants(conf_dir, conf, run, dontrun, here):
                             path = os.path.realpath(conf_data[variant][x]['path'])
                             if os.path.commonprefix([path, herepath]) == path:
                                 here_found.append(variant)
-                                print("Found variant of here:" + variant)
-                                print(
-                                    "path:{}, herepath:{}, common prefix:{}".format(
-                                        path, herepath, os.path.commonprefix([path, herepath])
-                                    )
-                                )
+                                Log.info("Found variant for current path: %s", variant)
+                                Log.debug("path:%s, herepath:%s, common prefix:%s", path, herepath, os.path.commonprefix([path, herepath]))
             if len(here_found) == 0:
-                print("No variants found for here path '" + here + "'")
+                Log.warning("No variants found for path `%s`", here)
             else:
-                print("Variants found at here path '{}': {}".format(here, ", ".join(here_found)))
+                Log.info("Variants found for path `%s`: %s", here, ", ".join(here_found))
 
             if len(here_found):
-                print("Varaints found here: {}")
+                Log.info("Variants found for current path")
 
         if len(run):
-            print("Specified variants: {}".format(", ".join(run)))
+            Log.info("Specified variants: %s", ", ".join(run))
             confs = {}
             for variant in run:
                 if variant in conf_data:
                     confs[variant] = conf_data[variant]
                 else:
-                    print("Variant '{}' not exists in readed conf".format(variant))
+                    Log.warning("Variant `%s` does not exist in loaded config", variant)
         else:
-            print("All the variants")
+            Log.info("Using all variants")
             confs = conf_data
 
         if len(dontrun):
-            print("Skipping variants: {}".format(", ".join(dontrun)))
+            Log.info("Skipping variants: %s", ", ".join(dontrun))
             for variant in dontrun:
                 if variant in confs:
                     del confs[variant]
@@ -131,9 +128,9 @@ def list(conf_dir, conf, run, dontrun, verbose, here, mainconf=""):
 
     confs = process_variants(conf_dir, conf, run, dontrun, here)
 
-    print("variants:")
+    Log.info("Variants:")
     if verbose:
-        print(json.dumps(confs, indent=4))
+        Log.info("%s", json.dumps(confs, indent=4))
     else:
         maxlen = 0
         for varname in confs:
@@ -144,12 +141,12 @@ def list(conf_dir, conf, run, dontrun, verbose, here, mainconf=""):
                 description = confs[varname]["description"]
             else:
                 description = "No description available"
-            print(varname + (" " * (maxlen - len(varname))) + ": " + description)
+            Log.info("%s: %s", varname + (" " * (maxlen - len(varname))), description)
 
 
 @cli.command()
 def test():
-    print("test")
+    Log.info("test")
 
 
 @cli.command()
@@ -193,12 +190,12 @@ def backup(conf_dir, conf, run, dontrun, verbose, here, mainconf="", skip_freque
 
     confs = process_variants(conf_dir, conf, run, dontrun, here)
 
-    print("variants to run:")
-    print(json.dumps(confs, indent=4))
+    Log.info("Variants to run:")
+    Log.info("%s", json.dumps(confs, indent=4))
     if confs and len(confs):
         backup_go(confs, verbose=verbose, skip_frequency_check=skip_frequency_check)
     else:
-        print("Where are no variants to run")
+        Log.warning("There are no variants to run")
 
 
 @cli.command()
@@ -241,7 +238,7 @@ def sweep(conf_dir, conf, run, dontrun, verbose, imitate, here, mainconf=""):
 
     confs = process_variants(conf_dir, conf, run, dontrun, here)
 
-    print("variants to sweep:{}".format(len(confs)))
+    Log.info("Variants to sweep: %s", len(confs))
 
     if confs and len(confs):
         sweep_go(confs, verbose, imitate)

--- a/LinuxTimeMachine/sweep.py
+++ b/LinuxTimeMachine/sweep.py
@@ -21,7 +21,7 @@ def sweep(variants, verbose=False, imitate=False):
             sweep_conf = SweepConfList(sweep_params)
 
             if len(sweep_conf.parsed_sweep_conf) == 0:
-                print("Sweep for variant `{}` isn't configured".format(variant_name))
+                Log.warning("Sweep for variant `%s` is not configured", variant_name)
                 continue
 
             dirs = Console.get_backup_dirs_with_dates(
@@ -41,30 +41,25 @@ def sweep(variants, verbose=False, imitate=False):
 
             to_remove_cnt = 0
             for swcl in sweep_conf.parsed_sweep_conf:
-                print(swcl.get_conf_decription())
+                Log.info(swcl.get_conf_decription())
                 if swcl.data_array:
                     swcl.data_array = sorted(swcl.data_array, key=lambda item: item['time_from_now'])
                     to_remove = swcl.sweep_data_items("time_from_now", "to_remove")
                     to_remove_cnt += to_remove
                     if verbose:
-                        print("    Found items:")
+                        Log.info("    Found items:")
                         for i in range(len(swcl.data_array)):
-                            print("        item: {}, {}".format(
-                                swcl.data_array[i]['name'], "REMOVE" if swcl.data_array[i]['to_remove'] else "KEEP"
-                            )
-                            )
+                            Log.info("        item: %s, %s", swcl.data_array[i]["name"], "REMOVE" if swcl.data_array[i]["to_remove"] else "KEEP")
                     else:
-                        print("    Found data items:{}, items to remove:{}, items to stay:{}".format(
-                            len(swcl.data_array), to_remove, len(swcl.data_array) - to_remove)
-                        )
+                        Log.info("    Found data items:%s, items to remove:%s, items to keep:%s", len(swcl.data_array), to_remove, len(swcl.data_array) - to_remove)
                 else:
-                    print("    No data items in this interval")
+                    Log.info("    No data items in this interval")
 
             if to_remove_cnt > 0:
 
                 if not imitate:
 
-                    print("Removing data items...")
+                    Log.info("Removing data items...")
                     removed_cnt = 0
                     for swcl in reversed(sweep_conf.parsed_sweep_conf):
                         for i in reversed(range(len(swcl.data_array))):
@@ -72,12 +67,12 @@ def sweep(variants, verbose=False, imitate=False):
                             if item['to_remove']:
                                 removed_cnt += 1
                                 if verbose:
-                                    print("Removing {} ({} of {})".format(item['name'], removed_cnt, to_remove_cnt))
+                                    Log.info("Removing %s (%s of %s)", item["name"], removed_cnt, to_remove_cnt)
                                 Console.rm_dir(variant["dest"]["path"] + "/" + item['name'], variant["dest"]["host"])
                 else:
-                    print("Not removing data items, caused by --imitate flag")
+                    Log.info("Not removing data items because of --imitate flag")
             else:
-                print("Everything clean, nothing to remove")
+                Log.info("Everything is clean, nothing to remove")
 
 
         except TypeError as e:
@@ -122,7 +117,7 @@ class LastSweepPeriod:
         self.src_string = str_period
         period_matches = {}
         if not Tools.re_match(
-                "^(last\ ((?P<num>[0-9\.]+)\ )?(?P<unit>hour|year|month|day|week)s?)|(?P<other>all others?)$",
+                r"^(last\ ((?P<num>[0-9\.]+)\ )?(?P<unit>hour|year|month|day|week)s?)|(?P<other>all others?)$",
                 str_period.strip(),
                 period_matches
         ):
@@ -193,7 +188,7 @@ class SweepInterval:
 
         interval_matches = {}
         if not Tools.re_match(
-                "^(?P<all>all)|((?P<items>[0-9\.]+)\ per\ (?P<num>[0-9\.]+)?\ ?(?P<unit>hour|year|month|day|week)s?)$",
+                r"^(?P<all>all)|((?P<items>[0-9\.]+)\ per\ (?P<num>[0-9\.]+)?\ ?(?P<unit>hour|year|month|day|week)s?)$",
                 str_interval,
                 interval_matches
         ):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 click==8.1.6
 pexpect==4.8.0
 PyYAML==6.0.1
-raven==6.10.0
-yapsy==1.12.2
+sentry-sdk==2.27.0

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['click', 'pexpect', 'pyyaml'],
+    install_requires=['click', 'pexpect', 'pyyaml', 'sentry-sdk'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
### Motivation

- Modernize the codebase for current Python 3 ecosystems by removing legacy dependencies and unsafe loaders.
- Replace the old Raven client with a Sentry-compatible integration and avoid failing when Sentry is not installed.
- Eliminate fragile string regexes and plain `print()`s in favor of raw regex literals and structured logging.

### Description

- Replace Raven (`raven`) with a `sentry_sdk` wrapper (`SentryClientWrapper`) and update `ravenClient()` to return a dummy object when DSN or `sentry_sdk` is not available, while logging appropriately.
- Remove dynamic Python config and plugin loading support: drop `.py` config parsing and disable the Yapsy plugin subsystem (plugin manager set to `None` and emits a warning).
- Use safe YAML loading via `yaml.safe_load` and update config file detection to accept only `.json`/`.yml`/`.yaml` files.
- Convert many regular-expression and string patterns to raw-strings (`r

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9b47613c832490be11b8c1691f5a)