### PR TITLE
Prevent duplicate log messages

### DIFF
--- a/LinuxTimeMachine/common.py
+++ b/LinuxTimeMachine/common.py
@@ -22,6 +22,12 @@ class Log:
     def __init__(self, loglevel=logging.DEBUG, logfile=sys.stdout):
         self.logger = logging.getLogger("LinuxTimeMachine")
         self.logger.setLevel(loglevel)
+        self.logger.propagate = False
+
+        for handler in self.logger.handlers[:]:
+            self.logger.removeHandler(handler)
+            handler.close()
+
         self.logger.addHandler(
             logging.StreamHandler(logfile)
         )

--- a/tests/tools_test.py
+++ b/tests/tools_test.py
@@ -1,6 +1,9 @@
 from datetime import timedelta
 import unittest
 from LinuxTimeMachine.backup import Tools
+from LinuxTimeMachine.backup import Log
+import io
+import logging
 
 class ToolsTestCase(unittest.TestCase):
     def test_get_nested_dict_value(self):
@@ -20,3 +23,35 @@ class ToolsTestCase(unittest.TestCase):
             "1 days 2 seconds 3 milliseconds 4 minutes 5 hours 6 weeks"
         ))
 
+
+
+class LogTestCase(unittest.TestCase):
+    def test_reset_replaces_handler_without_duplicate_messages(self):
+        first_stream = io.StringIO()
+        second_stream = io.StringIO()
+
+        Log.I(logging.INFO, first_stream, reset=True)
+        Log.info("first")
+        Log.I(logging.INFO, second_stream, reset=True)
+        Log.info("second")
+
+        self.assertEqual(first_stream.getvalue(), "first\n")
+        self.assertEqual(second_stream.getvalue(), "second\n")
+        self.assertEqual(len(Log.I().logger.handlers), 1)
+
+    def test_logger_does_not_propagate_to_root_handlers(self):
+        root_stream = io.StringIO()
+        root_handler = logging.StreamHandler(root_stream)
+        root_logger = logging.getLogger()
+        root_logger.addHandler(root_handler)
+
+        try:
+            local_stream = io.StringIO()
+            Log.I(logging.INFO, local_stream, reset=True)
+            Log.info("local")
+
+            self.assertEqual(local_stream.getvalue(), "local\n")
+            self.assertEqual(root_stream.getvalue(), "")
+        finally:
+            root_logger.removeHandler(root_handler)
+            root_handler.close()


### PR DESCRIPTION
### Motivation
- After switching print statements to `Log.info`, log messages were observed to be duplicated because the named logger kept accumulating handlers and also propagated messages to the root logger.

### Description
- Set `self.logger.propagate = False` and remove and close any existing handlers before adding a new `StreamHandler` in `LinuxTimeMachine/common.py` to avoid duplicate emissions.
- Added `LogTestCase` regression tests to `tests/tools_test.py` that verify handler replacement when `Log.I(..., reset=True)` is called and that messages do not propagate to root handlers.
- Updated `tests/tools_test.py` imports to include `Log`, `io`, and `logging` for the new tests.

### Testing
- Ran `python -m unittest tests.tools_test` which executed 4 tests and passed (`OK`).
- Ran `python -m unittest discover -s tests -p '*test.py'` which failed due to unrelated import errors in `tests/conf_test.py` and `tests/consoletest.py` (errors importing `Conf` and `logging` from `LinuxTimeMachine.backup`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a2a7140a88324bccc382094b9b040)